### PR TITLE
set Style/StringLiteralsInInterpolation to doble quotes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -63,6 +63,9 @@ Style/SingleLineBlockParams:
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes
+  
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes
 
 Style/WhileUntilModifier:
   MaxLineLength: 120


### PR DESCRIPTION
Set Style/StringLiteralsInInterpolation to doble quotes to avoid Style/StringLiterals conflict.